### PR TITLE
Update to Realm v0.86.0

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     compile 'com.android.support:recyclerview-v7:22.0.+'
-    compile 'io.realm:realm-android:0.82.+'
+    compile 'io.realm:realm-android:0.86.0'
 
     compile 'com.github.thorbenprimke:realm-recyclerview:0.9.9'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 22
+    compileSdkVersion 23
     buildToolsVersion "22.0.1"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
@@ -19,7 +19,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:recyclerview-v7:22.0.+'
+    compile 'com.android.support:recyclerview-v7:23.1.1'
     compile 'io.realm:realm-android:0.86.0'
 
     compile 'com.github.thorbenprimke:realm-recyclerview:0.9.9'

--- a/library/src/main/java/co/moonmonkeylabs/realmsearchview/RealmSearchAdapter.java
+++ b/library/src/main/java/co/moonmonkeylabs/realmsearchview/RealmSearchAdapter.java
@@ -45,8 +45,8 @@ public abstract class RealmSearchAdapter<T extends RealmObject, VH extends Realm
     /**
      * Creates a {@link RealmSearchAdapter} with only the filter columnKey. The defaults are:
      * - useContains: true
-     * - caseSensitive: false
-     * - sortAscending: true
+     * - casing: insensitive
+     * - sortOrder: ascending
      * - sortKey: filterKey
      * - basePredicate: not set
      */

--- a/library/src/main/java/co/moonmonkeylabs/realmsearchview/RealmSearchAdapter.java
+++ b/library/src/main/java/co/moonmonkeylabs/realmsearchview/RealmSearchAdapter.java
@@ -2,13 +2,10 @@ package co.moonmonkeylabs.realmsearchview;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
-import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.TextView;
-
-import org.w3c.dom.Text;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.GenericArrayType;
@@ -20,12 +17,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.realm.Case;
 import io.realm.Realm;
 import io.realm.RealmBasedRecyclerViewAdapter;
 import io.realm.RealmObject;
 import io.realm.RealmQuery;
 import io.realm.RealmResults;
-import io.realm.RealmViewHolder;
+import io.realm.Sort;
 
 /**
  * A custom adapter for the {@link RealmSearchView}. It has options to customize the filtering.
@@ -39,8 +37,8 @@ public abstract class RealmSearchAdapter<T extends RealmObject, VH extends Realm
     private String filterKey;
 
     private boolean useContains;
-    private boolean useCaseSensitive;
-    private boolean sortAscending;
+    private Case casing;
+    private Sort sortOrder;
     private String sortKey;
     private String basePredicate;
 
@@ -56,7 +54,7 @@ public abstract class RealmSearchAdapter<T extends RealmObject, VH extends Realm
             @NonNull Context context,
             @NonNull Realm realm,
             @NonNull String filterKey) {
-        this(context, realm, filterKey, true, false, true, filterKey, null);
+        this(context, realm, filterKey, true, Case.INSENSITIVE, Sort.ASCENDING, filterKey, null);
     }
 
     /**
@@ -67,16 +65,16 @@ public abstract class RealmSearchAdapter<T extends RealmObject, VH extends Realm
             @NonNull Realm realm,
             @NonNull String filterKey,
             boolean useContains,
-            boolean useCaseSensitive,
-            boolean sortAscending,
+            Case casing,
+            Sort sortOrder,
             String sortKey,
             String basePredicate) {
         super(context, null, false, false);
         this.realm = realm;
         this.filterKey = filterKey;
         this.useContains = useContains;
-        this.useCaseSensitive = useCaseSensitive;
-        this.sortAscending = sortAscending;
+        this.casing = casing;
+        this.sortOrder = sortOrder;
         this.sortKey = sortKey;
         this.basePredicate = basePredicate;
 
@@ -102,22 +100,22 @@ public abstract class RealmSearchAdapter<T extends RealmObject, VH extends Realm
         RealmQuery<T> where = realm.where(clazz);
         if (input.isEmpty() && basePredicate != null) {
             if (useContains) {
-                where = where.contains(filterKey, basePredicate, useCaseSensitive);
+                where = where.contains(filterKey, basePredicate, casing);
             } else {
-                where = where.beginsWith(filterKey, basePredicate, useCaseSensitive);
+                where = where.beginsWith(filterKey, basePredicate, casing);
             }
         } else if (!input.isEmpty()) {
             if (useContains) {
-                where = where.contains(filterKey, input, useCaseSensitive);
+                where = where.contains(filterKey, input, casing);
             } else {
-                where = where.beginsWith(filterKey, input, useCaseSensitive);
+                where = where.beginsWith(filterKey, input, casing);
             }
         }
 
         if (sortKey == null) {
             businesses = where.findAll();
         } else {
-            businesses = where.findAllSorted(sortKey, sortAscending);
+            businesses = where.findAllSorted(sortKey, sortOrder);
         }
         updateRealmResults(businesses);
     }
@@ -142,15 +140,15 @@ public abstract class RealmSearchAdapter<T extends RealmObject, VH extends Realm
     /**
      * Sets if the filtering is case sensitive or case insensitive.
      */
-    public void setUseCaseSensitive(boolean useCaseSensitive) {
-        this.useCaseSensitive = useCaseSensitive;
+    public void setCasing(Case casing) {
+        this.casing = casing;
     }
 
     /**
      * Sets if the sort order is ascending or descending.
      */
-    public void setSortAscending(boolean sortAscending) {
-        this.sortAscending = sortAscending;
+    public void setSortOrder(Sort sortOrder) {
+        this.sortOrder = sortOrder;
     }
 
     /**


### PR DESCRIPTION
I've updated the Realm dependency to v0.86.0. The main difference is the introduction of Enums for the sort order and casing. I've kept the naming identical to that used in Realm.

This results in some straight forward changes to the constructor and related setters. If you really want to it would be easy enough to keep the original booleans in your API. Though I suggest going with the newer Enums just to be consistent with Realm.

I've also updated the Android support library and the compile and target SDKs.
