### PR TITLE
Allow subclass to adjust the filter by overriding #createFilter

### DIFF
--- a/library/src/main/java/co/moonmonkeylabs/realmsearchview/RealmSearchAdapter.java
+++ b/library/src/main/java/co/moonmonkeylabs/realmsearchview/RealmSearchAdapter.java
@@ -97,8 +97,7 @@ public abstract class RealmSearchAdapter<T extends RealmObject, VH extends Realm
         return (VH) vh;
     }
 
-    public void filter(String input) {
-        RealmResults<T> businesses;
+    protected RealmQuery<T> createFilter(String input) {
         RealmQuery<T> where = realm.where(clazz);
         if (input.isEmpty() && basePredicate != null) {
             if (useContains) {
@@ -114,12 +113,19 @@ public abstract class RealmSearchAdapter<T extends RealmObject, VH extends Realm
             }
         }
 
+        return where;
+    }
+
+    public void filter(String input) {
+        RealmResults<T> results;
+        RealmQuery<T> where = createFilter(input);
+
         if (sortKey == null) {
-            businesses = where.findAll();
+            results = where.findAll();
         } else {
-            businesses = where.findAllSorted(sortKey, sortOrder);
+            results = where.findAllSorted(sortKey, sortOrder);
         }
-        updateRealmResults(businesses);
+        updateRealmResults(results);
     }
 
     /**


### PR DESCRIPTION
For one of my views I need to adjust the filter. Specifically I want to filter out hidden objects.
With this change I can do this easily:

``` java
    @Override
    protected RealmQuery<Client> createFilter(String input) {
        return super.createFilter(input)
                .equalTo("hidden", false);
    }
```

With the original code I have to reimplement `#filter` entirely.

On a side-note, would you consider either marking the member fields of `RealmSearchAdapter` protected (as you already did for `clazz`) or adding the appropriate getters?
